### PR TITLE
Add task for Dokka documentation coverage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@
 - add language management
 - add selector management + on text language too (not only dimension/color)
 - add bottom/top screen not react to transition
+- add Dokka documentation coverage for every Kotlin source file
 
 
 - Improve: update view have a knowledge of previous element and next element to avoid overhear job (aka generate validators)


### PR DESCRIPTION
## Summary
- note the need to extend Dokka documentation coverage to every Kotlin source file in the TODO backlog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56cb599188322ac39e890dabd3a65